### PR TITLE
chore: E2Eテストを一時的に無効化

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
 
   e2e-test:
     runs-on: self-hosted
+    if: false  # 一時的に無効化（将来復活予定）
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 概要

GitHub ActionsのE2Eテストを一時的に無効化する。

## 変更内容

- `e2e-test`ジョブに`if: false`を追加してスキップするよう設定
- 将来復活させるため、削除ではなく条件で無効化

## 復活方法

`if: false`の行を削除するだけでOK。

## 確認事項

- [x] YAML構文が正しいこと
- [x] 他のジョブ（test, danger）に影響がないこと