### PR TITLE
chore: GitHub ActionsのClaudeパスを更新

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: .claude/settings.json
-          path_to_claude_code_executable: /Users/hiragram/.local/bin/claude
+          path_to_claude_code_executable: /Users/hiragram/.bun/bin/claude
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: .claude/settings.json
-          path_to_claude_code_executable: /Users/hiragram/.local/bin/claude
+          path_to_claude_code_executable: /Users/hiragram/.bun/bin/claude
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
 


### PR DESCRIPTION
## 概要

GitHub Actionsのself-hostedランナーで使用するclaudeの実行ファイルパスを更新します。

## 変更内容

- `.github/workflows/claude.yml` のclaudeパスを更新
- `.github/workflows/claude-code-review.yml` のclaudeパスを更新

パスの変更:
- 旧: `/Users/hiragram/.local/bin/claude`
- 新: `/Users/hiragram/.bun/bin/claude`

## 確認事項

- [x] 両ファイルのパスが正しく更新されていること
- [ ] GitHub Actionsが正常に動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)