### PR TITLE
docs: xcodebuildで使用するシミュレータをCLAUDE.mdに明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,10 @@
 - OkumukaのCLAUDE.md: @docs/old-CLAUDE.md
     - OkumukaのCLAUDE.mdをそのままコピペしたもの。
 - 開発ルールについては従いつつ、Okumuka固有の記載は適宜無視してもよい。
+
+## 開発環境
+
+### シミュレータ
+
+- xcodebuildでテストやビルドを実行する際は **iPhone 17 Pro** シミュレータを使用すること
+- iPhone 16シリーズのシミュレータはインストールされていないため使用不可


### PR DESCRIPTION
## 概要

CLAUDE.mdにxcodebuildでテストやビルドを実行する際のシミュレータ指定を追加。

## 変更内容

- iPhone 17 Proシミュレータを使用することを明記
- iPhone 16シリーズはインストールされていないことを注記

## 確認事項

- [x] ドキュメント更新のみのためビルド確認は不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)