### PR TITLE
feat: new-worktreeスクリプトでCLAUDE_CODE_TASK_LIST_IDを設定

### DIFF
--- a/scripts/new-worktree
+++ b/scripts/new-worktree
@@ -19,4 +19,5 @@ echo "Created worktree: worktrees/$name"
 # worktreeディレクトリでzellijセッションを開始
 cd "worktrees/$name"
 direnv allow
+export CLAUDE_CODE_TASK_LIST_ID="$name"
 zellij --new-session-with-layout claude-dev -s "$name"


### PR DESCRIPTION
## 概要

new-worktreeスクリプトでzellijセッション起動前に`CLAUDE_CODE_TASK_LIST_ID`環境変数をworktree名で設定するようにした。

## 変更内容

- `scripts/new-worktree`にexport文を追加
- zellijセッション内で起動されるClaude Codeがworktreeごとに独立したタスクリストを持てるようになる

## 確認事項

- [x] スクリプトの構文チェック（`bash -n`）が通ること

🤖 Generated with [Claude Code](https://claude.ai/code)