### PR TITLE
fix: Claude Code Actionでbotアクターを許可

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: "*"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: .claude/settings.json
           path_to_claude_code_executable: /Users/hiragram/.bun/bin/claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: "*"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: .claude/settings.json
           path_to_claude_code_executable: /Users/hiragram/.bun/bin/claude


### PR DESCRIPTION
## 概要

Claudeボットがコミットを追加した際にClaude Code Reviewワークフローが失敗する問題を修正します。

## 変更内容

- `.github/workflows/claude-code-review.yml` に `allowed_bots: "*"` を追加
- `.github/workflows/claude.yml` に `allowed_bots: "*"` を追加

## 背景

`anthropics/claude-code-action@v1` はセキュリティ上の理由からデフォルトで全てのBotをブロックします。Claudeボットがコミットを追加した際、以下のエラーが発生していました：

```
Actor type: Bot
Error: Prepare step failed with error: Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`allowed_bots: "*"` を設定することで、全てのbotアクターからのトリガーを許可します。

## 確認事項

- [x] ワークフローのYAML構文が正しいこと
- [ ] Claudeボットがコミットした際にワークフローが正常に実行されること