### PR TITLE
chore: デフォルト言語を英語に変更

### DIFF
--- a/AppCore/Localizable.xcstrings
+++ b/AppCore/Localizable.xcstrings
@@ -1,5 +1,5 @@
 {
-  "sourceLanguage" : "ja",
+  "sourceLanguage" : "en",
   "strings" : {
     "" : {
 

--- a/Tweakable.xcodeproj/project.pbxproj
+++ b/Tweakable.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 				};
 			};
 			buildConfigurationList = 605EE8032EECE98A00201738 /* Build configuration list for PBXProject "Tweakable" */;
-			developmentRegion = ja;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,


### PR DESCRIPTION
## 概要

日英以外の言語設定のユーザーに英語版がフォールバックとして表示されるよう、デフォルト言語を日本語から英語に変更。

## 変更内容

- `project.pbxproj`の`developmentRegion`を`ja`から`en`に変更
- `Localizable.xcstrings`の`sourceLanguage`を`ja`から`en`に変更

## 確認事項

- [x] ビルドが通ること
- [x] 既存機能に影響がないこと