### PR TITLE
fix: E2Eテストのflaky問題を修正

### DIFF
--- a/TweakableUITests/RecipeErrorUITests.swift
+++ b/TweakableUITests/RecipeErrorUITests.swift
@@ -27,6 +27,7 @@ final class RecipeExtractionErrorUITests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        app?.terminate()
         app = nil
     }
 
@@ -90,6 +91,7 @@ final class RecipeSubstitutionErrorUITests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        app?.terminate()
         app = nil
     }
 

--- a/TweakableUITests/RecipeUITests.swift
+++ b/TweakableUITests/RecipeUITests.swift
@@ -25,6 +25,7 @@ final class RecipeUITests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        app?.terminate()
         app = nil
     }
 


### PR DESCRIPTION
## Summary

- E2EテストのtearDownで`app?.terminate()`を追加し、テスト間でアプリ状態がリークしないよう修正
- シミュレータ名を`iPhone 17 Pro`に統一（CI workflow、スナップショット再生成スクリプト）

## 問題

`testNavigateToRecipeView`が毎回失敗していた。原因は前のテスト（`testIngredientTapOpensSubstitutionSheet`）でナビゲーションした状態のままアプリが終了されず、次のテスト開始時にその状態が残っていたため。

## 修正内容

1. **UIテストのtearDownを修正**
   - `RecipeUITests.swift`
   - `RecipeErrorUITests.swift`（2クラス分）

2. **シミュレータ名の統一**
   - `.github/workflows/test.yml`（3箇所）
   - `scripts/regenerate-snapshot-reference`

## Test plan

- [x] ローカルでE2Eテスト全27件が2回連続でPASS
- [ ] CIでE2Eテストが完走

🤖 Generated with [Claude Code](https://claude.com/claude-code)