### PR TITLE
fix: E2Eテストのシミュレータ競合によるxctrunner起動失敗を修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
 
   e2e-test:
     runs-on: self-hosted
+    needs: test
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- e2e-testジョブにtestジョブへの依存関係（`needs: test`）を追加
- self-hostedランナーで両ジョブが同時実行され、シミュレータが競合する問題を解消

## Root Cause
CIログを分析した結果、`test`ジョブと`e2e-test`ジョブが同時刻（`2026-01-31T01:41:35Z`）に開始されていることが判明。1台のself-hostedランナーで同じシミュレータ（iPhone 17）を使用するため、UIテスト（xctrunner）の起動に失敗していた。

## Test plan
- [ ] PRのCIが通ることを確認
- [ ] testジョブ完了後にe2e-testジョブが開始されることをログで確認

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)