### PR TITLE
refactor: requiresPremium()のテスト追加とローカライズキーの統一

### DIFF
--- a/AppCore/Localizable.xcstrings
+++ b/AppCore/Localizable.xcstrings
@@ -1122,21 +1122,22 @@
       },
       "extractionState": "manual"
     },
-    "substitution_error_premium_required" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Premium subscription required for substitution feature"
+    "substitution_error_premium_required": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Premium subscription required for substitution feature"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "置き換え機能にはプレミアム登録が必要です"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "置き換え機能にはプレミアム登録が必要です"
           }
         }
-      }
+      },
+      "extractionState": "manual"
     },
     "substitution_error_unexpected": {
       "localizations": {

--- a/AppCore/Store/AppStore.swift
+++ b/AppCore/Store/AppStore.swift
@@ -102,7 +102,7 @@ public final class AppStore {
     /// - Returns: プレミアムユーザーの場合は `true`、非プレミアムの場合は `false`
     private func requiresPremium() -> Bool {
         guard state.subscription.isPremium else {
-            send(.recipe(.substitutionFailed(String(localized: "substitution_error_premium_required", bundle: .app))))
+            send(.recipe(.substitutionFailed(String(localized: .substitutionErrorPremiumRequired))))
             return false
         }
         return true

--- a/AppCoreTests/Mocks/MockRevenueCatServiceForTests.swift
+++ b/AppCoreTests/Mocks/MockRevenueCatServiceForTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import AppCore
+
+/// ユニットテスト用のモックRevenueCatサービス（遅延なし）
+final class MockRevenueCatServiceForTests: RevenueCatServiceProtocol, @unchecked Sendable {
+    /// プレミアムユーザーとして振る舞うかどうか
+    var isPremium: Bool = false
+
+    func checkPremiumStatus() async throws -> Bool {
+        return isPremium
+    }
+
+    func fetchPackages() async throws -> [SubscriptionPackage] {
+        return []
+    }
+
+    func purchase(packageID: String) async throws -> PurchaseResult {
+        return .success
+    }
+
+    func restorePurchases() async throws -> Bool {
+        return isPremium
+    }
+}

--- a/AppCoreTests/Store/AppStorePremiumTests.swift
+++ b/AppCoreTests/Store/AppStorePremiumTests.swift
@@ -1,0 +1,140 @@
+import Testing
+@testable import AppCore
+
+/// AppStoreのプレミアム機能テスト
+@Suite
+@MainActor
+struct AppStorePremiumTests {
+
+    // MARK: - Test Helpers
+
+    private func makeSampleRecipe() -> Recipe {
+        Recipe(
+            title: "テスト用チキンカレー",
+            ingredientsInfo: Ingredients(
+                servings: "2人分",
+                items: [
+                    Ingredient(name: "鶏もも肉", amount: "300g"),
+                    Ingredient(name: "玉ねぎ", amount: "1個"),
+                    Ingredient(name: "カレールー", amount: "4かけ")
+                ]
+            ),
+            steps: [
+                CookingStep(stepNumber: 1, instruction: "鶏肉を一口大に切る"),
+                CookingStep(stepNumber: 2, instruction: "玉ねぎをみじん切りにする")
+            ]
+        )
+    }
+
+    // MARK: - requiresPremium Tests
+
+    @Test("非プレミアムユーザーが置き換えをリクエストするとエラーが発生する")
+    func requestSubstitution_whenNotPremium_setsError() async {
+        // Arrange
+        let mockRevenueCatService = MockRevenueCatServiceForTests()
+        mockRevenueCatService.isPremium = false
+
+        let mockRecipeService = MockRecipeExtractionService()
+        let store = AppStore(
+            recipeExtractionService: mockRecipeService,
+            revenueCatService: mockRevenueCatService
+        )
+
+        // サブスクリプション状態を非プレミアムに設定
+        store.send(.subscription(.subscriptionStatusLoaded(isPremium: false)))
+
+        // レシピを設定
+        let recipe = makeSampleRecipe()
+        store.send(.recipe(.recipeLoaded(recipe)))
+
+        // 置き換え対象を設定
+        let targetIngredient = recipe.ingredientsInfo.items[0]
+        store.send(.recipe(.openSubstitutionSheet(ingredient: targetIngredient)))
+
+        // Act
+        store.send(.recipe(.requestSubstitution(prompt: "鶏肉を豚肉に変えて")))
+
+        // 副作用が実行されるまで待機
+        try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+
+        // Assert
+        #expect(store.state.recipe.errorMessage != nil)
+        #expect(store.state.recipe.errorMessage?.contains("Premium") == true ||
+                store.state.recipe.errorMessage?.contains("プレミアム") == true)
+    }
+
+    @Test("プレミアムユーザーは置き換えをリクエストできる")
+    func requestSubstitution_whenPremium_doesNotSetPremiumError() async {
+        // Arrange
+        let mockRevenueCatService = MockRevenueCatServiceForTests()
+        mockRevenueCatService.isPremium = true
+
+        let mockRecipeService = MockRecipeExtractionService()
+        let store = AppStore(
+            recipeExtractionService: mockRecipeService,
+            revenueCatService: mockRevenueCatService
+        )
+
+        // サブスクリプション状態をプレミアムに設定
+        store.send(.subscription(.subscriptionStatusLoaded(isPremium: true)))
+
+        // レシピを設定
+        let recipe = makeSampleRecipe()
+        store.send(.recipe(.recipeLoaded(recipe)))
+
+        // 置き換え対象を設定
+        let targetIngredient = recipe.ingredientsInfo.items[0]
+        store.send(.recipe(.openSubstitutionSheet(ingredient: targetIngredient)))
+
+        // Act
+        store.send(.recipe(.requestSubstitution(prompt: "鶏肉を豚肉に変えて")))
+
+        // 副作用が実行されるまで待機
+        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // Assert - プレミアムエラーは発生しない
+        // (他のエラーは発生しうる：モックなのでsubstitutionRecipeが設定されていないなど)
+        let error = store.state.recipe.errorMessage
+        if let error = error {
+            #expect(!error.contains("Premium") && !error.contains("プレミアム"))
+        }
+    }
+
+    @Test("非プレミアムユーザーが追加置き換えをリクエストするとエラーが発生する")
+    func requestAdditionalSubstitution_whenNotPremium_setsError() async {
+        // Arrange
+        let mockRevenueCatService = MockRevenueCatServiceForTests()
+        mockRevenueCatService.isPremium = false
+
+        let mockRecipeService = MockRecipeExtractionService()
+        let store = AppStore(
+            recipeExtractionService: mockRecipeService,
+            revenueCatService: mockRevenueCatService
+        )
+
+        // サブスクリプション状態を非プレミアムに設定
+        store.send(.subscription(.subscriptionStatusLoaded(isPremium: false)))
+
+        // レシピを設定
+        let recipe = makeSampleRecipe()
+        store.send(.recipe(.recipeLoaded(recipe)))
+
+        // プレビューを設定（追加置き換えはプレビュー状態から始まる）
+        store.send(.recipe(.substitutionPreviewReady(recipe)))
+
+        // 置き換え対象を設定
+        let targetIngredient = recipe.ingredientsInfo.items[0]
+        store.send(.recipe(.openSubstitutionSheet(ingredient: targetIngredient)))
+
+        // Act
+        store.send(.recipe(.requestAdditionalSubstitution(prompt: "さらに野菜を変えて")))
+
+        // 副作用が実行されるまで待機
+        try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+
+        // Assert
+        #expect(store.state.recipe.errorMessage != nil)
+        #expect(store.state.recipe.errorMessage?.contains("Premium") == true ||
+                store.state.recipe.errorMessage?.contains("プレミアム") == true)
+    }
+}


### PR DESCRIPTION
## 概要

`requiresPremium()` メソッドのテストを追加し、ローカライズキーの参照方法を他のコードと統一しました。

Closes #41

## 変更内容

- **テスト追加**
  - `AppStorePremiumTests`: 3つのテストケースを追加
    - 非プレミアムユーザーが置き換えをリクエストするとエラーになることを検証
    - プレミアムユーザーは置き換えをリクエストできることを検証  
    - 追加置き換えリクエストでも同様にプレミアムチェックが機能することを検証
  - `MockRevenueCatServiceForTests`: ユニットテスト用の遅延なしモックを追加

- **ローカライズキーの統一**
  - 文字列リテラル `"substitution_error_premium_required"` をドット記法 `.substitutionErrorPremiumRequired` に変更
  - xcstringsのフォーマットを他のキーと統一（`extractionState: "manual"` 追加）

## 確認事項

- [x] ビルドが通ること
- [x] 既存テストが通ること
- [x] 新規テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)