### PR TITLE
chore: e2eテストをsersoft-gmbh/xcodebuild-actionに移行

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,32 +65,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install xcbeautify
-        run: |
-          if ! command -v xcbeautify &> /dev/null; then
-            brew install xcbeautify
-          fi
-
       - name: Run E2E Tests
-        run: |
-          set -o pipefail
-          xcodebuild test \
-            -project Tweakable.xcodeproj \
-            -scheme TweakableUITests \
-            -destination 'platform=iOS Simulator,name=iPhone 17' \
-            -resultBundlePath E2ETestResults.xcresult \
-            CODE_SIGNING_ALLOWED=NO \
-            2>&1 | xcbeautify --report junit --report-path e2e-test-reports
-
-      - name: Publish E2E test results
-        uses: mikepenz/action-junit-report@v5
-        if: always()
+        uses: sersoft-gmbh/xcodebuild-action@v4
         with:
-          report_paths: 'e2e-test-reports/junit.xml'
-          include_passed: true
-          detailed_summary: true
-          annotate_only: true
-          check_name: 'E2E Test Results'
+          project: Tweakable.xcodeproj
+          scheme: TweakableUITests
+          destination: 'platform=iOS Simulator,name=iPhone 17'
+          action: test
+          result-bundle-path: E2ETestResults.xcresult
+          build-settings: CODE_SIGNING_ALLOWED=NO
+          retry-tests-on-failure: true
+          test-iterations: 3
+          parallel-testing-enabled: false
 
       - name: Upload E2E test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概要

flakyなe2eテストの安定化のため、xcodebuild直接呼び出しからsersoft-gmbh/xcodebuild-action@v4に移行します。

## 変更内容

- `xcodebuild test` 直接呼び出し → `sersoft-gmbh/xcodebuild-action@v4` に変更
- `retry-tests-on-failure: true` でテスト失敗時に自動リトライ
- `test-iterations: 3` で最大3回まで再試行
- `parallel-testing-enabled: false` でシミュレータ競合を防止
- xcbeautify/JUnitレポート出力を削除（不要のため）

## 背景

- e2eテストがflakyで不安定
- xcodebuild組み込みのリトライ機能を活用することで安定化を図る
- [sersoft-gmbh/xcodebuild-action](https://github.com/sersoft-gmbh/xcodebuild-action)は2025年11月にv4.0.0がリリースされ、アクティブにメンテされている

## 確認事項

- [ ] ビルドが通ること
- [ ] e2eテストが安定して通ること
- [ ] 既存機能に影響がないこと

🤖 Generated with [Claude Code](https://claude.ai/claude-code)