### PR TITLE
feat: 保存済みレシピのカスタマイズ承認時に自動保存

### DIFF
--- a/AppCore/Store/AppStore.swift
+++ b/AppCore/Store/AppStore.swift
@@ -189,6 +189,14 @@ public final class AppStore {
                 send(.recipe(.recipeDeleteFailed(error.localizedDescription)))
             }
 
+        case .approveSubstitution:
+            // 保存済みレシピのカスタマイズなら自動保存
+            // currentRecipe が savedRecipes に存在するか確認
+            if let currentRecipe = state.recipe.currentRecipe,
+               state.recipe.savedRecipes.contains(where: { $0.id == currentRecipe.id }) {
+                send(.recipe(.saveRecipe))
+            }
+
         default:
             // その他のアクションは副作用なし
             break


### PR DESCRIPTION
## 概要

置き換え機能でカスタマイズしたレシピが、詳細画面から戻ると元に戻ってしまう問題を修正しました。

## 変更内容

- `AppStore.handleRecipeSideEffects`に`approveSubstitution`ケースを追加
- 保存済みレシピ（`savedRecipes`にIDが存在）をカスタマイズした場合、承認時に自動で`saveRecipe`を発行
- 未保存の新規レシピは自動保存しない（ユーザーが明示的に保存ボタンを押す必要あり）
- テストを2件追加（TDDで実装）

## 確認事項

- [x] ビルドが通ること
- [x] 全201テストがパスすること
- [x] 既存機能に影響がないこと

🤖 Generated with [Claude Code](https://claude.ai/code)