### PR TITLE
fix: Quick Actionのコールドローンチ時の動作を修正

### DIFF
--- a/AppCore/AppDelegate.swift
+++ b/AppCore/AppDelegate.swift
@@ -54,19 +54,20 @@ public class AppDelegate: NSObject, UIApplicationDelegate {
         Purchases.configure(withAPIKey: apiKey)
     }
 
-    // MARK: - Quick Actions (Home Screen Shortcuts)
+    // MARK: - Scene Configuration
 
+    #if DEBUG
     public func application(
         _ application: UIApplication,
-        performActionFor shortcutItem: UIApplicationShortcutItem,
-        completionHandler: @escaping (Bool) -> Void
-    ) {
-        switch shortcutItem.type {
-        case "app.hiragram.Tweakable.debugMenu":
-            NotificationCenter.default.post(name: Self.debugMenuShortcutNotification, object: nil)
-            completionHandler(true)
-        default:
-            completionHandler(false)
-        }
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(
+            name: nil,
+            sessionRole: connectingSceneSession.role
+        )
+        configuration.delegateClass = SceneDelegate.self
+        return configuration
     }
+    #endif
 }

--- a/AppCore/SceneDelegate.swift
+++ b/AppCore/SceneDelegate.swift
@@ -1,0 +1,51 @@
+//
+//  SceneDelegate.swift
+//  AppCore
+//
+//  Created by Claude on 2026/02/01.
+//
+
+import UIKit
+
+#if DEBUG
+public class SceneDelegate: NSObject, UIWindowSceneDelegate {
+
+    public func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        // コールドローンチ時のQuick Action処理
+        if let shortcutItem = connectionOptions.shortcutItem {
+            handleShortcutItem(shortcutItem)
+        }
+    }
+
+    public func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        // ウォームローンチ時のQuick Action処理
+        let handled = handleShortcutItem(shortcutItem)
+        completionHandler(handled)
+    }
+
+    @discardableResult
+    private func handleShortcutItem(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
+        switch shortcutItem.type {
+        case "app.hiragram.Tweakable.debugMenu":
+            // 少し遅延させて通知を投稿（UIが準備できるのを待つ）
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                NotificationCenter.default.post(
+                    name: AppDelegate.debugMenuShortcutNotification,
+                    object: nil
+                )
+            }
+            return true
+        default:
+            return false
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## 概要

ホーム画面のアイコン長押しメニュー（Quick Action）からデバッグメニューを選択した際、アプリが終了状態（コールドローンチ）だとデバッグメニューが開かない問題を修正しました。

## 原因

従来の実装では `AppDelegate.application(_:performActionFor:completionHandler:)` でQuick Actionを処理していましたが、このメソッドはアプリがバックグラウンドにいる状態（ウォームローンチ）でのみ呼ばれます。

アプリが完全に終了している状態からの起動（コールドローンチ）では、`SceneDelegate.scene(_:willConnectTo:options:)` で `connectionOptions.shortcutItem` を処理する必要があります。

## 変更内容

- `SceneDelegate.swift` を新規作成
  - `scene(_:willConnectTo:options:)` でコールドローンチ時のQuick Actionを処理
  - `windowScene(_:performActionFor:completionHandler:)` でウォームローンチ時のQuick Actionを処理
  - UIの準備時間を考慮して0.5秒遅延して通知を投稿
- `AppDelegate.swift` を修正
  - `configurationForConnecting` を追加して `SceneDelegate` を設定
  - 既存の `performActionFor` は `SceneDelegate` に移動したため削除

## 確認事項

- [x] ビルドが通ること
- [x] テストが通ること（243件すべてパス）
- [ ] コールドローンチでデバッグメニューが開くこと（手動確認）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)