### PR TITLE
fix: オンボーディング完了後にTipを表示するよう修正

### DIFF
--- a/AppCore/Tips/AppTips.swift
+++ b/AppCore/Tips/AppTips.swift
@@ -24,6 +24,11 @@ struct AddRecipeButtonTip: Tip {
 
     var rules: [Rule] {
         [
+            // オンボーディングが完了していること
+            #Rule(TipEvents.onboardingCompleted) {
+                $0.donations.count >= 1
+            },
+            // レシピをまだ追加していないこと
             #Rule(TipEvents.recipeAdded) {
                 $0.donations.count == 0
             }

--- a/AppCore/Tips/TipEvents.swift
+++ b/AppCore/Tips/TipEvents.swift
@@ -12,6 +12,14 @@ import TipKit
 /// アクション完了時に `sendDonation()` を呼び出すことで、
 /// donation数が1以上になり、そのイベントに紐づくTipが非表示になる。
 enum TipEvents {
+    // MARK: - Onboarding Events
+
+    /// オンボーディングを完了したイベント
+    ///
+    /// オンボーディング完了後にTipを表示するための条件として使用。
+    /// `AddRecipeButtonTip` はこのイベントが1回以上donateされるまで表示されない。
+    static let onboardingCompleted = Tips.Event(id: "onboardingCompleted")
+
     // MARK: - Recipe Events
 
     /// レシピを追加したイベント

--- a/AppCore/Views/Onboarding/OnboardingView.swift
+++ b/AppCore/Views/Onboarding/OnboardingView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TipKit
 
 /// Onboarding flow with 3 pages introducing the app's features
 struct OnboardingView: View {
@@ -80,6 +81,7 @@ struct OnboardingView: View {
             .accessibilityIdentifier("onboarding_button_next")
         } else {
             Button {
+                TipEvents.onboardingCompleted.sendDonation()
                 onComplete()
             } label: {
                 Text(.onboardingGetStarted)


### PR DESCRIPTION
## 概要

オンボーディングモーダル表示中にTipKitのTip（「最初のレシピを追加しよう」）が被って表示される問題を修正しました。

## 変更内容

- `TipEvents.swift`: `onboardingCompleted`イベントを追加
- `AppTips.swift`: `AddRecipeButtonTip`のrulesにオンボーディング完了条件を追加
- `OnboardingView.swift`: オンボーディング完了時に`onboardingCompleted`イベントをdonate

## 動作

- **修正前**: オンボーディングモーダルが表示された直後にTipが被って表示される
- **修正後**: オンボーディング完了後にホーム画面でTipが表示される

## 確認事項

- [x] ビルドが通ること
- [x] テストが通ること（220テスト全パス）
- [x] オンボーディング中にTipが表示されないこと
- [x] オンボーディング完了後にTipが表示されること