### PR TITLE
fix: LicensePlistの参照先を正しいXcodeプロジェクト名に修正

### DIFF
--- a/license_plist.yml
+++ b/license_plist.yml
@@ -1,4 +1,4 @@
 options:
-  xcodeprojPath: "Okumuka.xcodeproj"
+  xcodeprojPath: "Tweakable.xcodeproj"
   prefix: Acknowledgements
   singlePage: true


### PR DESCRIPTION
## 概要

iOS設定アプリのライセンスページが空になっていた問題を修正。

## 原因

`license_plist.yml`で参照しているXcodeプロジェクトのパスが旧名`Okumuka.xcodeproj`のままだったため、LicensePlistがSPM依存関係を読み取れず、`Acknowledgements.plist`が生成されていなかった。

## 変更内容

- `license_plist.yml`の`xcodeprojPath`を`Tweakable.xcodeproj`に修正

## 確認事項

- [x] ビルドが通ること
- [x] 設定アプリ → Tweakable → ライセンス でライブラリ一覧が表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)