### PR TITLE
fix: e2eテストの待機条件を削除済みUI要素から更新

### DIFF
--- a/TweakableUITests/Helpers/UITestHelper.swift
+++ b/TweakableUITests/Helpers/UITestHelper.swift
@@ -30,7 +30,6 @@ enum RecipeAccessibilityIDs {
     static let errorRetryButton = "recipe_button_retry"
     static func ingredientItem(_ index: Int) -> String { "recipe_button_ingredient_\(index)" }
     static func stepItem(_ index: Int) -> String { "recipe_button_step_\(index)" }
-    static let shoppingListButton = "recipe_button_shoppingList"
     static let modifiedBadge = "recipe_badge_modified"
 
     // SubstitutionSheetView
@@ -89,9 +88,9 @@ enum UITestHelper {
     /// レシピ詳細画面が表示されるまで待機
     /// - Returns: レシピ詳細画面に到達できたかどうか
     static func waitForRecipeView(app: XCUIApplication, timeout: TimeInterval = 15) -> Bool {
-        // ツールバーのショッピングリストボタンが表示されることを確認
-        let shoppingListButton = app.buttons[RecipeAccessibilityIDs.shoppingListButton]
-        return shoppingListButton.waitForExistence(timeout: timeout)
+        // 最初の材料ボタンが表示されることでレシピ詳細画面への到達を確認
+        let firstIngredient = app.buttons[RecipeAccessibilityIDs.ingredientItem(0)]
+        return firstIngredient.waitForExistence(timeout: timeout)
     }
 
     /// ローディング画面が表示されるまで待機

--- a/TweakableUITests/RecipeUITests.swift
+++ b/TweakableUITests/RecipeUITests.swift
@@ -194,9 +194,6 @@ final class RecipeUITests: XCTestCase {
         let firstStep = app.buttons[RecipeAccessibilityIDs.stepItem(0)]
         XCTAssertTrue(firstStep.exists, "調理工程が存在すること")
 
-        // 買い物リストボタンが存在する
-        let shoppingListButton = app.buttons[RecipeAccessibilityIDs.shoppingListButton]
-        XCTAssertTrue(shoppingListButton.exists, "買い物リストボタンが存在すること")
     }
 
     /// 材料の数がモックデータと一致することを確認


### PR DESCRIPTION
## 概要

CIのe2eテストが全テスト失敗していた問題を修正。

## 変更内容

- `UITestHelper.waitForRecipeView()` の待機条件を、削除済みの `shoppingListButton` から `ingredientItem(0)`（最初の材料ボタン）に変更
- `testRecipeViewElements()` 内の `shoppingListButton` 存在アサーションを削除
- 未使用になった `RecipeAccessibilityIDs.shoppingListButton` 定義を削除

## 背景

コミット 9a23657 でレシピ詳細画面のツールバー（買い物リスト・保存ボタン）が削除されたが、UIテスト側が追随していなかった。`waitForRecipeView()` が存在しないボタンを15秒待機してタイムアウトし、30/50テストが失敗していた。

## 確認事項

- [x] ビルドが通ること（`build-for-testing` 確認済み）
- [ ] e2eテストがCIで通ること
- [x] 既存機能に影響がないこと（テストコードのみの変更）