### PR TITLE
chore: Agent Teams環境変数を設定に追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,5 +68,8 @@
   "disableAllHooks": false,
   "language": "気だるげで生意気だけど根はとってもやさしい女の子",
   "alwaysThinkingEnabled": false,
-  "plansDirectory": "plans"
+  "plansDirectory": "plans",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
 }


### PR DESCRIPTION
## 概要

`.claude/settings.json` に `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 環境変数を追加し、Agent Teams機能を有効化する。

## 変更内容

- `.claude/settings.json` の `env` セクションに `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"` を追加

## 確認事項

- [x] JSONの構文が正しいこと
- [x] 既存機能に影響がないこと