### PR TITLE
feat: 全画面にデザインシステムの背景色を適用 & CIシミュレータ統一

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,14 @@ jobs:
             brew install xcbeautify
           fi
 
-      - name: Clean build
+      - name: Clean DerivedData and build
         run: |
+          rm -rf /tmp/CIDerivedData
           xcodebuild clean \
             -project Tweakable.xcodeproj \
             -scheme AppCore \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -derivedDataPath /tmp/CIDerivedData \
             CODE_SIGNING_ALLOWED=NO
 
       - name: Run tests
@@ -37,6 +39,7 @@ jobs:
             -project Tweakable.xcodeproj \
             -scheme AppCore \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -derivedDataPath /tmp/CIDerivedData \
             -resultBundlePath TestResults.xcresult \
             -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO \


### PR DESCRIPTION
## Summary
- 各画面（RecipeHome, RecipeView, AddRecipe, ShoppingLists, ShoppingListDetail）に `.background(ds.colors.backgroundPrimary.color)` を追加し、Midnight Bistroテーマのネイビー寄り背景色を実際に反映
- RecipeViewのヒーロー画像グラデーションを `systemBackground` からデザインシステムの色に変更
- CIのテスト用シミュレータを `iPhone 17` から `iPhone 17 Pro` に変更し、ローカル開発環境と統一

## Test plan
- [x] ローカルでスナップショットテスト全パス確認済み
- [x] スナップショットリファレンス画像を再生成済み
- [ ] CI（test, e2e-test）がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)