### PR TITLE
fix: ワークフローにissues: write権限を追加してstartup_failureを修正

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,6 +12,9 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  issues: write
+
 jobs:
   e2e-test:
     runs-on: self-hosted

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,6 +12,9 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  issues: write
+
 jobs:
   test:
     runs-on: self-hosted


### PR DESCRIPTION
## 概要

`unit-test.yml` と `e2e-test.yml` が `startup_failure` で即座に失敗し、ジョブが一切実行されない問題を修正。

## 変更内容

- `unit-test.yml` にトップレベル `permissions: issues: write` を追加
- `e2e-test.yml` にトップレベル `permissions: issues: write` を追加

## 原因

reusable workflow `create-test-failure-issue.yml` 内のジョブが `permissions: issues: write` を要求しているが、呼び出し元ワークフローでその権限が宣言されていなかった。

GitHub Actionsでは、reusable workflowで要求するpermissionsは呼び出し元で同等以上の権限が付与されていないと `startup_failure` になる。

エラーメッセージ:
> "The nested job 'create-fix-issue' is requesting 'issues: write', but is only allowed 'issues: none'."

## 確認事項

- [x] ワークフローYAMLの構文が正しいこと
- [ ] ワークフローが `startup_failure` にならず正常起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)