### PR TITLE
fix: issue作成時のGH_TOKENを削除してself-hostedランナーの認証を使用

### DIFF
--- a/.github/workflows/create-test-failure-issue.yml
+++ b/.github/workflows/create-test-failure-issue.yml
@@ -33,8 +33,6 @@ jobs:
     steps:
       - name: Check for existing open fix issue
         id: check-issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           if ! existing=$(gh issue list \
@@ -60,8 +58,6 @@ jobs:
 
       - name: Create fix issue
         if: steps.check-issue.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh issue create \
             --repo ${{ github.repository }} \


### PR DESCRIPTION
## 概要

テスト失敗時に自動作成されるissueが `claude.yml` ワークフローをトリガーしない問題を修正。

## 変更内容

- `create-test-failure-issue.yml` の2ステップから `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` を削除
- self-hostedランナーの `gh auth login` 認証情報（hiragramアカウント）が使われるようになる

## 原因

GitHubの仕様で、`GITHUB_TOKEN` で実行されたアクション（issue作成含む）は他のワークフローをトリガーしない（無限ループ防止）。`GH_TOKEN` 環境変数を削除することで、ランナーにログイン済みのアカウントの認証が使われ、issueが通常のユーザー名義で作成されるようになる。

## 確認事項

- [ ] ビルドが通ること
- [ ] テスト失敗時にissueが作成され、Claude Codeワークフローがトリガーされること