### PR TITLE
ci: PRごとにテストビルドを確認するワークフローを追加

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,23 @@
+name: Build Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-test:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build for testing
+        run: |
+          xcodebuild build-for-testing \
+            -project Tweakable.xcodeproj \
+            -scheme AppCore \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -derivedDataPath /tmp/CIDerivedData \
+            CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## 概要

PRの段階でテストコードのコンパイルが通ることを確認するCIワークフローを追加。

## 変更内容

- `.github/workflows/build-test.yml` を新規作成
- `main` ブランチへのPR時に `xcodebuild build-for-testing` を実行
- テスト実行はせずビルドのみ確認するため高速に完了する
- 既存の `unit-test.yml` と同じプロジェクト・スキーム・destination設定を踏襲

## 確認事項

- [x] ワークフロー定義が既存CIと整合していること
- [ ] PRトリガーでワークフローが正しく発火すること