### PR TITLE
ci: junitレポートとsummary表示を削除

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -51,16 +51,7 @@ jobs:
             -resultBundlePath TestResults.xcresult \
             -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO \
-            2>&1 | xcbeautify --report junit --report-path test-reports
-
-      - name: Publish test results
-        uses: mikepenz/action-junit-report@v5
-        if: always()
-        with:
-          report_paths: 'test-reports/junit.xml'
-          include_passed: true
-          detailed_summary: true
-          annotate_only: true
+            2>&1 | xcbeautify
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- xcbeautifyがSwift Testingのテスト結果をjunitレポートに含めないため、PreviewTestsしかsummaryに表示されず誤解を招いていた
- `mikepenz/action-junit-report` ステップとxcbeautifyの `--report junit` オプションを削除
- xcresultのアーティファクトアップロードは維持

## Test plan
- [ ] CIが正常に通ること
- [ ] summaryに誤解を招く不完全なテスト結果が表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)