### PR TITLE
feat: オンボーディング中にシードデータの画像をプリフェッチ

### DIFF
--- a/AppCore/RootView.swift
+++ b/AppCore/RootView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// アプリのルートビュー
 public struct RootView: View {
     @State private var store: AppStore
+    @State private var imagePrefetchService = ImagePrefetchService()
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
     /// UIテスト用: オンボーディングを強制的にスキップするフラグ
@@ -67,6 +68,9 @@ public struct RootView: View {
             OnboardingView(onComplete: {
                 hasCompletedOnboarding = true
             })
+            .onAppear {
+                imagePrefetchService.startPrefetchingSeedImages()
+            }
         } else {
             RecipeHomeContainerView(store: store)
         }

--- a/AppCore/Services/ImagePrefetchService.swift
+++ b/AppCore/Services/ImagePrefetchService.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Nuke
+
+/// シードデータの画像をバックグラウンドでプリフェッチするサービス
+///
+/// オンボーディング画面表示中にプリフェッチを開始し、
+/// ユーザーがRecipeHome画面に遷移した時点でキャッシュから即座に表示できるようにする。
+/// LazyImageと同じImagePipeline.sharedを使用するため、
+/// プリフェッチした画像はLazyImageが自動的にキャッシュから読み込む。
+@MainActor
+final class ImagePrefetchService {
+    private let prefetcher: ImagePrefetcher
+
+    init() {
+        self.prefetcher = ImagePrefetcher(
+            pipeline: .shared,
+            destination: .memoryCache,
+            maxConcurrentRequestCount: 2
+        )
+        prefetcher.priority = .veryLow
+    }
+
+    /// シードデータの画像URLをプリフェッチ開始
+    func startPrefetchingSeedImages() {
+        let urls: [URL] = SeedData.recipes().compactMap { recipe in
+            guard let first = recipe.imageURLs.first else { return nil }
+            switch first {
+            case .remote(let url):
+                return url
+            default:
+                return nil
+            }
+        }
+
+        guard !urls.isEmpty else { return }
+        prefetcher.startPrefetching(with: urls)
+    }
+}


### PR DESCRIPTION
## 概要

シードデータ（Eitanのレシピ23件）の画像URLは eitanbernath.com でホストされており、サーバーの応答が遅い。RecipeHome画面に遷移してからLazyImageがon-demandで取得すると、placeholderが長時間表示されてしまう問題を改善する。

オンボーディング画面表示中にNukeの`ImagePrefetcher`を使ってバックグラウンドで画像をダウンロード・キャッシュし、オンボーディング完了後にRecipeHome画面を開いた瞬間にキャッシュヒットで即表示させる。

## 変更内容

- `ImagePrefetchService`を新規作成（`AppCore/Services/ImagePrefetchService.swift`）
  - NukeのImagePrefetcherの薄いラッパー
  - `SeedData.recipes()`からリモート画像URLを抽出してプリフェッチ
  - 優先度`.veryLow`、同時リクエスト数2でUI描画を妨げない
- `RootView`にプリフェッチ開始処理を追加（`AppCore/RootView.swift`）
  - `@State`でImagePrefetchServiceを保持
  - オンボーディングViewの`.onAppear`でプリフェッチ開始
  - オンボーディング完了後もダウンロード中のタスクは継続

## 技術的なポイント

- `ImagePipeline.shared`を共有するため、LazyImage側の変更は不要
- 既にキャッシュ済みのURLは自動的にスキップされる
- Reduxパターンには統合しない（fire-and-forget処理のため状態管理不要）

## 確認事項

- [x] ビルドが通ること
- [ ] 既存機能に影響がないこと