### PR TITLE
fix: 買い物リスト一覧画面の背景色を画面全体に適用

### DIFF
--- a/AppCore/Views/ShoppingList/ShoppingListsView.swift
+++ b/AppCore/Views/ShoppingList/ShoppingListsView.swift
@@ -34,7 +34,7 @@ struct ShoppingListsView: View {
                 listView
             }
         }
-        .background(ds.colors.backgroundPrimary.color)
+        .background(ds.colors.backgroundPrimary.color.ignoresSafeArea())
         .navigationTitle(String(localized: .shoppingListsTitle))
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {


### PR DESCRIPTION
## 概要

買い物リスト一覧画面（`ShoppingListsView`）の背景色がSafeArea内にしか描画されず、画面の上下にデフォルト背景が見える問題を修正。

## 変更内容

- `ShoppingListsView.swift` の `.background()` に `.ignoresSafeArea()` を追加し、背景色がSafeAreaを超えて画面全体に広がるように修正

## 確認事項

- [x] ビルドが通ること
- [x] スナップショットテスト全40件 pass
- [x] 既存機能に影響がないこと